### PR TITLE
Clean up rspec warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,8 +59,6 @@ group :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
-  # Easy installation and use of chromedriver to run system tests with Chrome
-  gem 'chromedriver-helper'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,8 +44,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     bindex (0.8.1)
@@ -66,9 +64,6 @@ GEM
       launchy
     childprocess (1.0.1)
       rake (< 13.0)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -93,7 +88,6 @@ GEM
     humanize (2.1.1)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    io-like (0.3.0)
     jaro_winkler (1.5.3)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
@@ -251,7 +245,6 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   capybara-screenshot (~> 1.0)
-  chromedriver-helper
   coffee-rails (~> 4.2)
   factory_bot_rails
   humanize (~> 2.1)

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,4 +1,7 @@
 class Player < ApplicationRecord
+  START_POSSITION = 1
+  END_POSSITION = 100
+
   validates :name, presence: true, allow_blank: false
   validates :position, presence:true, numericality: { only_integer: true }
 
@@ -21,7 +24,7 @@ class Player < ApplicationRecord
   private
 
   def valid_position?(position)
-    (0 < position) and (position < 101)
+    position >= START_POSSITION && position <= END_POSSITION
   end
 
 end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -24,7 +24,6 @@ class Player < ApplicationRecord
   private
 
   def valid_position?(position)
-    position >= START_POSSITION && position <= END_POSSITION
+    position.between?(START_POSSITION, END_POSSITION)
   end
-
 end

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -1,7 +1,4 @@
 FactoryBot.define do
-  STARTING = 1
-  ENDING = 100
-
   factory :game, class: Game do
     name { 'FAKE GAME' }
     current_player { 0 }
@@ -11,14 +8,19 @@ FactoryBot.define do
     trait :complete do
       players do
         [
-          Player.new(name: 'FAKE PLAYER ONE', position: ENDING)
+          Player.new(name: 'FAKE PLAYER ONE', position: Player::END_POSSITION)
         ]
       end
     end
 
     trait :has_players do
       players do
-        Array.new(5) { |i| Player.new(name: "FAKE PLAYER #{i.humanize.upcase}", position: STARTING) }
+        Array.new(5) do |i|
+          Player.new(
+            name: "FAKE PLAYER #{i.humanize.upcase}",
+            position: Player::START_POSSITION
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #62

## Changes
- Move start and finish to model Player class
- remove `chromedriver-helper` gem
  - As noted here: <https://github.com/SeleniumHQ/selenium/issues/7125>